### PR TITLE
Correctly parse the timestamp passed by grafana on 32bit systems

### DIFF
--- a/grafana/time.go
+++ b/grafana/time.go
@@ -197,7 +197,7 @@ func (n now) parseRelativeTime(s string) time.Time {
 }
 
 func parseAbsTime(s string) time.Time {
-	if timeInMs, err := strconv.Atoi(s); err == nil {
+	if timeInMs, err := strconv.ParseInt(s, 10, 64); err == nil {
 		return time.Unix(int64(timeInMs)/1000, 0)
 	}
 


### PR DESCRIPTION
First of thanks for your awesome pdf exporter.

When attempting to export a dashboard on a Raspberry PI I get the following error:
```
2018/04/11 01:47:36 Reporter called
2018/04/11 01:47:36 Called with api Token:
2018/04/11 01:47:36 Called without variable
2018/04/11 01:47:36 Called with dashboard: 000000006
2018/04/11 01:47:36 Called with time range: {1522838700000 1522852200000}
2018/04/11 01:47:36 Connecting to dashboard at http://localhost:3000/api/dashboards/uid/000000006
2018/04/11 01:47:36 Populated dashboard datastructure: [...]
[...]
2018/04/11 01:48:45 Downloading image  12 http://localhost:3000/render/d-solo/000000006/_?from=1522838700000&height=500&panelId=12&theme=light&to=1522852200000&width=1000
2018/04/11 01:49:24 http: panic serving [::1]:51104: 1522838700000 is not a recognised time format
goroutine 20 [running]:
net/http.(*conn).serve.func1(0x1076ac40)
        /usr/lib/go-1.7/src/net/http/server.go:1491 +0x9c
panic(0x318a38, 0x108284a8)
        /usr/lib/go-1.7/src/runtime/panic.go:458 +0x454
text/template.errRecover(0x107439d8)
        /usr/lib/go-1.7/src/text/template/exec.go:146 +0x6c
panic(0x318a38, 0x108284a8)
        /usr/lib/go-1.7/src/runtime/panic.go:458 +0x454
github.com/IzakMarais/reporter/grafana.parseAbsTime(0x10788572, 0xd, 0x0, 0x0, 0x0, 0x0)
        /home/flow/go/src/github.com/IzakMarais/reporter/grafana/time.go:204 +0x26c
github.com/IzakMarais/reporter/grafana.now.parseMoment(0xd25f4484, 0xe, 0x1e34563, 0x496e78, 0x10788572, 0xd, 0x0, 0x0, 0x0, 0x0)
        /home/flow/go/src/github.com/IzakMarais/reporter/grafana/time.go:164 +0x110
github.com/IzakMarais/reporter/grafana.now.parseHumanFriendlyBoundary(0xd25f4484, 0xe, 0x1e34563, 0x496e78, 0x10788572, 0xd, 0x0, 0x0, 0x0, 0x0, ...)
        /home/flow/go/src/github.com/IzakMarais/reporter/grafana/time.go:101 +0x78
github.com/IzakMarais/reporter/grafana.now.parseFrom(0xd25f4484, 0xe, 0x1e34563, 0x496e78, 0x10788572, 0xd, 0x0, 0x0, 0x0, 0x0)
        /home/flow/go/src/github.com/IzakMarais/reporter/grafana/time.go:92 +0x60
github.com/IzakMarais/reporter/grafana.TimeRange.FromFormatted(0x10788572, 0xd, 0x10788583, 0xd, 0x0, 0x0)
        /home/flow/go/src/github.com/IzakMarais/reporter/grafana/time.go:74 +0x6c
github.com/IzakMarais/reporter/report.(*templData·1).FromFormatted(0x10832370, 0x0, 0x0)
        <autogenerated>:3 +0x60
reflect.Value.call(0x345c68, 0x10832370, 0x293, 0x35b365, 0x4, 0x4a58c4, 0x0, 0x0, 0x0, 0x0, ...)
        /usr/lib/go-1.7/src/reflect/value.go:434 +0xd68
[...]
text/template.(*Template).Execute(0x107e0900, 0x47d050, 0x108282e8, 0x345c68, 0x10832370, 0x0, 0x0)
        /usr/lib/go-1.7/src/text/template/exec.go:175 +0x48
github.com/IzakMarais/reporter/report.(*report).generateTeXFile(0x1076c750, 0x10808240, 0x16, 0x1076b840, 0x34, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /home/flow/go/src/github.com/IzakMarais/reporter/report/report.go:195 +0x84c
github.com/IzakMarais/reporter/report.(*report).Generate(0x1076c750, 0x0, 0x0, 0x0, 0x0)
        /home/flow/go/src/github.com/IzakMarais/reporter/report/report.go:81 +0x298
main.ServeReportHandler.ServeHTTP(0x391964, 0x391970, 0x47ed80, 0x10780b40, 0x10766580)
        /home/flow/go/src/github.com/IzakMarais/reporter/cmd/grafana-reporter/handler.go:51 +0x22c
main.(*ServeReportHandler).ServeHTTP(0x1076e5d0, 0x47ed80, 0x10780b40, 0x10766580)
        <autogenerated>:1 +0xb0
github.com/IzakMarais/reporter/vendor/github.com/gorilla/mux.(*Router).ServeHTTP(0x1076a300, 0x47ed80, 0x10780b40, 0x10766580)
        /home/flow/go/src/github.com/IzakMarais/reporter/vendor/github.com/gorilla/mux/mux.go:159 +0x2f0
net/http.serverHandler.ServeHTTP(0x10788500, 0x47ed80, 0x10780b40, 0x10766480)
        /usr/lib/go-1.7/src/net/http/server.go:2202 +0x150
net/http.(*conn).serve(0x1076ac40, 0x47f238, 0x107692e0)
        /usr/lib/go-1.7/src/net/http/server.go:1579 +0xde8
created by net/http.(*Server).Serve
        /usr/lib/go-1.7/src/net/http/server.go:2293 +0x470
```

It seems like [strconv.Atoi](https://golang.org/pkg/strconv/#Atoi) returns an [int](https://golang.org/pkg/builtin/#int) which is only guaranteed to be 32bit in size and thus not big enough to store a grafana timestamp (ex: 1522838700000).
On 64bit systems int seems to be 64bit in size thus avoiding this issue.

[strconv.ParseInt](https://golang.org/pkg/strconv/#ParseInt) in contrast always returns an int64 and  correctly parses the timestamp on all systems.

Example:
https://play.golang.org/p/e3tg7Hb7Zy2