### PR TITLE
Allow positive relative time specifications

### DIFF
--- a/grafana/time.go
+++ b/grafana/time.go
@@ -50,7 +50,7 @@ const (
 )
 
 const (
-	relTimeRegExp      = "^now(-[0-9]+)([mhdwMy])$"
+	relTimeRegExp      = "^now([+-][0-9]+)([mhdwMy])$"
 	boundaryTimeRegExp = "^(.*?)/([dwMy])$"
 )
 


### PR DESCRIPTION
Grafana supports positive relative time specifications. This PR adds support for this to your reporter.