### PR TITLE
Fix Docker build, add ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # build
 FROM golang:1.8-stretch AS build
 WORKDIR /go/src/${owner:-github.com/IzakMarais}/reporter
-RUN apt-get update && apt-get install make git
+RUN apt-get update && apt-get -y install make git
 ADD . .
 RUN make build
 
@@ -10,7 +10,8 @@ FROM debian:stretch
 COPY util/texlive.profile /
 RUN PACKAGES="wget libswitch-perl" \
     && apt-get update \
-    && apt-get install -qq $PACKAGES --no-install-recommends \
+    && apt-get install -y -qq $PACKAGES --no-install-recommends \
+    && apt-get install -y ca-certificates --no-install-recommends \
     && wget -qO- http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz |tar xz \
     && cd install-tl-* \
     && ./install-tl -profile /texlive.profile \


### PR DESCRIPTION
Without '-y' option apt-get install stops on the confirmation stage and Docker build is failing. Also, added ca-certificates installation (not to PACKAGES variable, cause they are removed from the image later) in order to be able to communicate with Grafana via HTTPS.