### PR TITLE
Improved docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN make build
 
 # create image
 FROM debian:stretch
-COPY util/texlive.profile /texlive.profile
+COPY util/texlive.profile /
 
 RUN PACKAGES="wget libswitch-perl" \
         && apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,20 +7,26 @@ RUN make build
 
 # create image
 FROM debian:stretch
-COPY util/texlive.profile /
+COPY util/texlive.profile /texlive.profile
+
 RUN PACKAGES="wget libswitch-perl" \
-    && apt-get update \
-    && apt-get install -y -qq $PACKAGES --no-install-recommends \
-    && apt-get install -y ca-certificates --no-install-recommends \
-    && wget -qO- http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz |tar xz \
-    && cd install-tl-* \
-    && ./install-tl -profile /texlive.profile \
-    # Cleanup
-    && rm -rf install-tl-* \
-    && apt-get remove --purge -qq $PACKAGES \
-    && apt-get autoremove --purge -qq \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir /var/tex
+        && apt-get update \
+        && apt-get install -y -qq $PACKAGES --no-install-recommends \
+        && apt-get install -y ca-certificates --no-install-recommends \
+        && wget -qO- \
+          "https://github.com/yihui/tinytex/raw/master/tools/install-unx.sh" | \
+          sh -s - --admin --no-path \
+        && mv ~/.TinyTeX /opt/TinyTeX \
+        && /opt/TinyTeX/bin/*/tlmgr path add \
+        && tlmgr path add \
+        && chown -R root:staff /opt/TinyTeX \
+        && chmod -R g+w /opt/TinyTeX \
+        && chmod -R g+wx /opt/TinyTeX/bin \
+        # Cleanup
+        && apt-get remove --purge -qq $PACKAGES \
+        && apt-get autoremove --purge -qq \
+        && rm -rf /var/lib/apt/lists/*
+
 
 COPY --from=build /go/bin/grafana-reporter /usr/local/bin
 ENTRYPOINT [ "/usr/local/bin/grafana-reporter" ]


### PR DESCRIPTION
This docker file uses TinyTex instead of texlive, reading to an image 1/10 the size of the current image (See [here](https://hub.docker.com/r/sbaier1/grafana-reporter/tags))