### PR TITLE
Allowing variable height and width parameters for dashboards and panels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,82 @@
 tmp/**
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,57 +3,75 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:f14d1b50e0075fb00177f12a96dd7addf93d1e2883c25befd17285b779549795"
   name = "github.com/gopherjs/gopherjs"
   packages = ["js"]
+  pruneopts = "UT"
   revision = "296de816d4fe28b61803072c3f89360e9d1823ff"
 
 [[projects]]
+  digest = "1:160eabf7a69910fd74f29c692718bc2437c1c1c7d4c9dea9712357752a70e5df"
   name = "github.com/gorilla/context"
   packages = ["."]
+  pruneopts = "UT"
   revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
   version = "v1.1"
 
 [[projects]]
+  digest = "1:88aa9e326e2bd6045a46e00a922954b3e1a9ac5787109f49ac85366df370e1e5"
   name = "github.com/gorilla/mux"
   packages = ["."]
+  pruneopts = "UT"
   revision = "53c1911da2b537f792e7cafcb446b05ffe33b996"
   version = "v1.6.1"
 
 [[projects]]
+  digest = "1:1e15f4e455f94aeaedfcf9c75b3e1c449b5acba1551c58446b4b45be507c707b"
   name = "github.com/jtolds/gls"
   packages = ["."]
+  pruneopts = "UT"
   revision = "77f18212c9c7edc9bd6a33d383a7b545ce62f064"
   version = "v4.2.1"
 
 [[projects]]
+  digest = "1:361de06aa7ae272616cbe71c3994a654cc6316324e30998e650f7765b20c5b33"
   name = "github.com/pborman/uuid"
   packages = ["."]
+  pruneopts = "UT"
   revision = "e790cca94e6cc75c7064b1332e63811d4aae1a53"
   version = "v1.1"
 
 [[projects]]
+  digest = "1:7f7faf148cee89ac3dafe3ba751ee1a13fd83559726a8d281e6ee4cca60c2d82"
   name = "github.com/smartystreets/assertions"
   packages = [
     ".",
     "internal/go-render/render",
-    "internal/oglematchers"
+    "internal/oglematchers",
   ]
+  pruneopts = "UT"
   revision = "0b37b35ec7434b77e77a4bb29b79677cced992ea"
   version = "1.8.1"
 
 [[projects]]
+  digest = "1:a3e081e593ee8e3b0a9af6a5dcac964c67a40c4f2034b5345b2ad78d05920728"
   name = "github.com/smartystreets/goconvey"
   packages = [
     "convey",
     "convey/gotest",
-    "convey/reporting"
+    "convey/reporting",
   ]
+  pruneopts = "UT"
   revision = "9e8dc3f972df6c8fcc0375ef492c24d0bb204857"
   version = "1.6.3"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2f0059310c8aeb78e4f272162d6cd95df0cafe35aed54ce9b284138afa4ae036"
+  input-imports = [
+    "github.com/gorilla/mux",
+    "github.com/pborman/uuid",
+    "github.com/smartystreets/goconvey/convey",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ clean:
 
 .PHONY: docker-build
 docker-build:
-	@docker build -t izakmarais/grafana-reporter:2.3.0 -t izakmarais/grafana-reporter:latest .
+	@docker build -t izakmarais/grafana-reporter:2.4.1-beta -t izakmarais/grafana-reporter:latest .
 
 docker-push:
 	@docker push izakmarais/grafana-reporter

--- a/cmd/grafana-reporter/cmd.go
+++ b/cmd/grafana-reporter/cmd.go
@@ -38,6 +38,12 @@ func cmdHandler(router *mux.Router) error {
 	if template != nil && *template != "" {
 		rqStr += "&template=" + *template
 	}
+	if width != nil && *width != "" {
+		rqStr += "&width=" + *width
+	}
+	if height != nil && *height != "" {
+		rqStr += "&height=" + *height
+	}
 
 	rq, err := http.NewRequest("GET", fmt.Sprintf(rqStr, *dashboard, *apiKey, *timeSpan), nil)
 	if err != nil {

--- a/cmd/grafana-reporter/handler.go
+++ b/cmd/grafana-reporter/handler.go
@@ -112,6 +112,16 @@ func dashVariables(r *http.Request) url.Values {
 			for _, singleV := range v {
 				output.Add(k, singleV)
 			}
+		} else if k == "width" {
+			log.Println("Called with width: ", v)
+			for _, singleV := range v {
+				output.Add(k, singleV)
+			}
+		} else if k == "height" {
+			log.Println("Called with height: ", v)
+			for _, singleV := range v {
+				output.Add(k, singleV)
+			}
 		}
 	}
 	if len(output) == 0 {

--- a/cmd/grafana-reporter/main.go
+++ b/cmd/grafana-reporter/main.go
@@ -42,6 +42,8 @@ var apiVersion = flag.String("cmd_apiVersion", "v5", "Api version: [v4, v5]. Req
 var outputFile = flag.String("cmd_o", "out.pdf", "Output file. Required (and only used) in command line mode.")
 var timeSpan = flag.String("cmd_ts", "from=now-3h&to=now", "Time span. Required (and only used) in command line mode.")
 var template = flag.String("cmd_template", "", "Specify a custom TeX template file. Only used in command line mode, but is optional even there.")
+var width = flag.String("cmd_width", "", "Specify a width for the dashboard. Only used in command line mode, but is optional even there.")
+var height = flag.String("cmd_height", "", "Specify a width for the dashboard. Only used in command line mode, but is optional even there.")
 
 func main() {
 	flag.Parse()
@@ -78,7 +80,12 @@ func main() {
 		if template != nil && *template != "" {
 			log.Printf("Called with command line mode 'template' '%s'", *template)
 		}
-
+		if width != nil && *width != "" {
+			log.Printf("Called with command line mode 'width' '%s'", *width)
+		}
+		if height != nil && *height != "" {
+			log.Printf("Called with command line mode 'height' '%s'", *height)
+		}
 		if err := cmdHandler(router); err != nil {
 			log.Fatalln(err)
 		}

--- a/cmd/grafana-reporter/version.go
+++ b/cmd/grafana-reporter/version.go
@@ -16,8 +16,8 @@
 
 package main
 
-//When making new release also tag git repo and update Makefile docker-buil job
+//When making new release also tag git repo and update Makefile docker-build job
 const generatedMajor = "2"
-const generatedMinor = "3"
-const generatedRelease = "0"
+const generatedMinor = "4"
+const generatedRelease = "1-beta"
 const generatedGitHash = "124b9a35302b3e9d4746ec0cf643abfecda8c21d"

--- a/grafana/api.go
+++ b/grafana/api.go
@@ -169,27 +169,47 @@ func (g client) getPanelURL(p Panel, dashName string, t TimeRange) string {
 	values.Add("from", t.From)
 	values.Add("to", t.To)
 
+	dashDims := map[string]bool{
+		"width":  true,
+		"height": true,
+	}
+
+	var wMultiplier, hMultiplier float64 = 40, 40
+	var panelWidth, panelHeight int = 1000, 500
+
+	if gwidth := g.variables.Get("width"); gwidth != "" {
+		val, _ := strconv.ParseFloat(gwidth, 64)
+		wMultiplier = val / 24
+	}
+
+	if gheight := g.variables.Get("height"); gheight != "" {
+		panelHeight, _ := strconv.ParseFloat(gheight, 64)
+		hMultiplier = panelHeight / 24
+	}
+
 	if g.gridLayout {
-		width := int(p.GridPos.W * 40)
-		height := int(p.GridPos.H * 40)
+		width := int(p.GridPos.W * wMultiplier)
+		height := int(p.GridPos.H * hMultiplier)
 		values.Add("width", strconv.Itoa(width))
 		values.Add("height", strconv.Itoa(height))
 	} else {
 		if p.Is(SingleStat) {
-			values.Add("width", "300")
-			values.Add("height", "150")
+			values.Add("width", strconv.Itoa(int(float64(panelWidth)*.3)))
+			values.Add("height", strconv.Itoa(int(float64(panelHeight)*.3)))
 		} else if p.Is(Text) {
-			values.Add("width", "1000")
-			values.Add("height", "100")
+			values.Add("width", strconv.Itoa(panelWidth))
+			values.Add("height", strconv.Itoa(int(float64(panelHeight)*.2)))
 		} else {
-			values.Add("width", "1000")
-			values.Add("height", "500")
+			values.Add("width", strconv.Itoa(panelWidth))
+			values.Add("height", strconv.Itoa(panelHeight))
 		}
 	}
 
 	for k, v := range g.variables {
 		for _, singleValue := range v {
-			values.Add(k, singleValue)
+			if !dashDims[k] {
+				values.Add(k, singleValue)
+			}
 		}
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ Running without any flags assumes Grafana is reachable at `localhost:3000`:
 
     grafana-reporter
 
-Query available flags. Likely the only one you need to set is `-ip`. 
+Query available flags. Likely the only one you need to set is `-ip`.
 
     grafana-reporter --help
     -cmd_apiKey string
@@ -48,6 +48,10 @@ Query available flags. Likely the only one you need to set is `-ip`.
           Specify a custom TeX template file. Only used in command line mode, but is optional even there.
     -cmd_ts string
           Time span. Required (and only used) in command line mode. (default "from=now-3h&to=now")
+    -cmd_width string
+          Width parameter, optional, specifies width of entire dashboard in `grid-layout` mode, or width of the panel otherwise
+    -cmd_height string
+         Height parameter, optional, specifies height of entire dashboard in `grid-layout` mode, or height of the panel otherwise
     -grid-layout
           Enable grid layout (-grid-layout=1). Panel width and height will be calculated based off Grafana gridPos width and height.
     -ip string
@@ -60,7 +64,6 @@ Query available flags. Likely the only one you need to set is `-ip`.
           Check the SSL issuer and validity. Set this to false if your Grafana serves https using an unverified, self-signed certificate. (default true)
     -templates string
           Directory for custom TeX templates. (default "templates/")
-
 
 ### Generate a dashboard report
 
@@ -95,24 +98,22 @@ URL query parameter syntax, eg:
 **Time span**: The time span query parameter syntax is the same as used by Grafana.
 When you create a link from Grafana, you can enable the _Time range_ forwarding check-box.
 The link will render a dashboard with your current time range.  
-By default, the time range will be included as the report sub-title. 
-Times are displayed using the reporter's host server time zone. 
-
+By default, the time range will be included as the report sub-title.
+Times are displayed using the reporter's host server time zone.
 
 **variables**: The template variable query parameter syntax is the same as used by Grafana.
 When you create a link from Grafana, you can enable the _Variable values_ forwarding check-box.
 The link will render a dashboard with your current variable values.
 
-**apitoken**: A Grafana authentication api token. Use this if you have auth enabled on Grafana. 
+**apitoken**: A Grafana authentication api token. Use this if you have auth enabled on Grafana.
 Syntax: `apitoken={your-tokenstring}`. If you are getting `Got Status 401 Unauthorized, message: {"message":"Unauthorized"}`
-error messages, typically it is because you forgot to set this parameter. 
+error messages, typically it is because you forgot to set this parameter.
 
 **template**: Optionally specify a custom TeX template file.
 Syntax `template=templateName` implies the grafana-reporter should have access to a template file on the server at `templates/templateName.tex`.
 The `templates` directory can be set with a command line parameter.
 See the LaTeX code in `texTemplate.go` as an example of what variables are available and how to access them.
-Also see [this issue](https://github.com/IzakMarais/reporter/issues/50) for an example. 
-
+Also see [this issue](https://github.com/IzakMarais/reporter/issues/50) for an example.
 
 ### Command line mode
 
@@ -159,4 +160,4 @@ or, the [GoConvey](http://goconvey.co/) webGUI:
 A new release requires changes to the git tag, `cmd/grafana-reporter/version.go` and `Makefile: docker-build` job.
 
 Build the Docker image and push to Dockerhub. Build the Windows and Linux binaries and upload to Github
-using `make buildall`. 
+using `make buildall`.


### PR DESCRIPTION
_Why:_
Allowing specification for width and height parameters, to change rendering of charts.
I have a tricky situation, and it's basically to get around Grafana's convenience rendering.
Based on the width of the rendered screen, keys on the X axis are limited like so:
![Screen Shot 2020-02-12 at 4 37 26 PM](https://user-images.githubusercontent.com/665336/74379557-04e93380-4db6-11ea-994d-bf6880e09776.png)
Outside of making changes in the Grafana base code, changing the width parameter can give us the values that we need, at the expense of comfortable reading size, like so:
![Screen Shot 2020-02-12 at 4 39 08 PM](https://user-images.githubusercontent.com/665336/74380139-036c3b00-4db7-11ea-96d8-89dd12dd83ca.png)

_This change addresses the need by:_
This change allows for rendered dashboard size specification in `grid-layout` mode, and panel size otherwise (in proportion according to the type of panel).
It works in both web request mode and CLI mode, with the new params specified to allow for it.