### PR TITLE
Add option to set report title in cmd mode

### DIFF
--- a/cmd/grafana-reporter/cmd.go
+++ b/cmd/grafana-reporter/cmd.go
@@ -39,6 +39,10 @@ func cmdHandler(router *mux.Router) error {
 		rqStr += "&template=" + *template
 	}
 
+	if title != nil && *title != "" {
+		rqStr += "&title=" + *title
+	}
+
 	rq, err := http.NewRequest("GET", fmt.Sprintf(rqStr, *dashboard, *apiKey, *timeSpan), nil)
 	if err != nil {
 		return err

--- a/cmd/grafana-reporter/handler.go
+++ b/cmd/grafana-reporter/handler.go
@@ -35,7 +35,7 @@ import (
 // ServeReportHandler interface facilitates testsing the reportServing http handler
 type ServeReportHandler struct {
 	newGrafanaClient func(url string, apiToken string, variables url.Values, sslCheck bool, gridLayout bool) grafana.Client
-	newReport        func(g grafana.Client, dashName string, time grafana.TimeRange, texTemplate string, gridLayout bool) report.Report
+	newReport        func(g grafana.Client, dashName string, time grafana.TimeRange, texTemplate string, texTitle string, gridLayout bool) report.Report
 }
 
 // RegisterHandlers registers all http.Handler's with their associated routes to the router
@@ -52,7 +52,7 @@ func RegisterHandlers(router *mux.Router, reportServerV4, reportServerV5 ServeRe
 func (h ServeReportHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	log.Print("Reporter called")
 	g := h.newGrafanaClient(*proto+*ip, apiToken(req), dashVariables(req), *sslCheck, *gridLayout)
-	rep := h.newReport(g, dashID(req), time(req), texTemplate(req), *gridLayout)
+	rep := h.newReport(g, dashID(req), time(req), texTemplate(req), texTitle(req), *gridLayout)
 
 	file, err := rep.Generate()
 	if err != nil {
@@ -135,4 +135,13 @@ func texTemplate(r *http.Request) string {
 	}
 
 	return string(customTemplate)
+}
+
+func texTitle(r *http.Request) string {
+	customTitle := r.URL.Query().Get("title")
+	if customTitle == "" {
+		return ""
+	}
+	log.Println("Called with title:", customTitle)
+	return customTitle
 }

--- a/cmd/grafana-reporter/main.go
+++ b/cmd/grafana-reporter/main.go
@@ -42,6 +42,7 @@ var apiVersion = flag.String("cmd_apiVersion", "v5", "Api version: [v4, v5]. Req
 var outputFile = flag.String("cmd_o", "out.pdf", "Output file. Required (and only used) in command line mode.")
 var timeSpan = flag.String("cmd_ts", "from=now-3h&to=now", "Time span. Required (and only used) in command line mode.")
 var template = flag.String("cmd_template", "", "Specify a custom TeX template file. Only used in command line mode, but is optional even there.")
+var title = flag.String("cmd_title", "", "Specify a custom title for the report. If empty, the title is taken from the Grafana dahsboard name.")
 
 func main() {
 	flag.Parse()
@@ -77,6 +78,9 @@ func main() {
 		log.Printf("Called with command line mode 'timeSpan' '%s'", *timeSpan)
 		if template != nil && *template != "" {
 			log.Printf("Called with command line mode 'template' '%s'", *template)
+		}
+		if title != nil && *title != "" {
+			log.Printf("Called with command line mode 'title' '%s'", *title)
 		}
 
 		if err := cmdHandler(router); err != nil {

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,8 @@ Query available flags. Likely the only one you need to set is `-ip`.
           Output file. Required (and only used) in command line mode. (default "out.pdf")
     -cmd_template string
           Specify a custom TeX template file. Only used in command line mode, but is optional even there.
+    -cmd_title
+          Specify a custom title for the report. If empty, the title is taken from the Grafana dahsboard name.
     -cmd_ts string
           Time span. Required (and only used) in command line mode. (default "from=now-3h&to=now")
     -grid-layout

--- a/report/report.go
+++ b/report/report.go
@@ -42,6 +42,7 @@ type report struct {
 	gClient     grafana.Client
 	time        grafana.TimeRange
 	texTemplate string
+	texTitle    string
 	dashName    string
 	tmpDir      string
 	dashTitle   string
@@ -55,11 +56,11 @@ const (
 
 // New creates a new Report.
 // texTemplate is the content of a LaTex template file. If empty, a default tex template is used.
-func New(g grafana.Client, dashName string, time grafana.TimeRange, texTemplate string, gridLayout bool) Report {
-	return new(g, dashName, time, texTemplate, gridLayout)
+func New(g grafana.Client, dashName string, time grafana.TimeRange, texTemplate string, texTitle string, gridLayout bool) Report {
+	return new(g, dashName, time, texTemplate, texTitle, gridLayout)
 }
 
-func new(g grafana.Client, dashName string, time grafana.TimeRange, texTemplate string, gridLayout bool) *report {
+func new(g grafana.Client, dashName string, time grafana.TimeRange, texTemplate string, texTitle string, gridLayout bool) *report {
 	if texTemplate == "" {
 		if gridLayout {
 			texTemplate = defaultGridTemplate
@@ -69,7 +70,7 @@ func new(g grafana.Client, dashName string, time grafana.TimeRange, texTemplate 
 
 	}
 	tmpDir := filepath.Join("tmp", uuid.New())
-	return &report{g, time, texTemplate, dashName, tmpDir, ""}
+	return &report{g, time, texTemplate, texTitle, dashName, tmpDir, ""}
 }
 
 // Generate returns the report.pdf file.  After reading this file it should be Closed()
@@ -81,6 +82,9 @@ func (rep *report) Generate() (pdf io.ReadCloser, err error) {
 		return
 	}
 	rep.dashTitle = dash.Title
+	if rep.texTitle != "" {
+		dash.Title = rep.texTitle
+	}
 
 	err = rep.renderPNGsParallel(dash)
 	if err != nil {


### PR DESCRIPTION
This adds an additional command-line option -cmd-title which allows to
overwrite the default title (i.e. dashboard name). Depending on the dashboard
naming scheme, or the particular time-range of the report, the user might want
to set a custom title (like `Daily report for...') without having to use custom
templates.