### PR TITLE
Timezone support

### DIFF
--- a/cmd/grafana-reporter/handler.go
+++ b/cmd/grafana-reporter/handler.go
@@ -93,7 +93,7 @@ func dashID(r *http.Request) string {
 
 func time(r *http.Request) grafana.TimeRange {
 	params := r.URL.Query()
-	t := grafana.NewTimeRange(params.Get("from"), params.Get("to"))
+	t := grafana.NewTimeRange(params.Get("from"), params.Get("to"), params.Get("timezone"))
 	log.Println("Called with time range:", t)
 	return t
 }

--- a/grafana/api.go
+++ b/grafana/api.go
@@ -168,6 +168,7 @@ func (g client) getPanelURL(p Panel, dashName string, t TimeRange) string {
 	values.Add("panelId", strconv.Itoa(p.Id))
 	values.Add("from", t.From)
 	values.Add("to", t.To)
+	values.Add("timezone", t.Timezone)
 
 	if g.gridLayout {
 		width := int(p.GridPos.W * 40)


### PR DESCRIPTION
This allows the user to configure the timeframe timezone on-the-fly.

```from=now-6h&to=now&timezone=UTC```
Mon Jan 25 05:24:01 UTC 2021 
to 
Mon Jan 25 11:24:01 UTC 2021

```from=now-6h&to=now&timezone=MST```
Sun Jan 24 22:24:30 MST 2021 
to 
Mon Jan 25 04:24:30 MST 2021