### PR TITLE
removed all vulnerabilities according to grype

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ buildall: build buildlinux
 
 .PHONY: build
 build: 
-	go install -v github.com/IzakMarais/reporter/cmd/grafana-reporter
+	go install -v github.com/IzakMarais/reporter/cmd/grafana-reporter@latest
 
 .PHONY: buildlinux 
 buildlinux: 	


### PR DESCRIPTION
We are using this container image to create a PDF report on a regular schedule and were a bit worried about potential security vulnerabilities reported by https://github.com/anchore/grype#installation - therefore I'd suggest to switch to a smaller alpine based image. I don't know go / TeX well enough to estimate, if this change may break some things - at least our report still looks good.

another benefit may also be a smaller image size :)

As mentioned: no clue about go, thus the change in the Makefile may break some developer workflow ? but it seems to be needed for docker build to work in this constellation?